### PR TITLE
Added possibility to specify Serial for communication

### DIFF
--- a/BitsAndDroidsFlightConnector.cpp
+++ b/BitsAndDroidsFlightConnector.cpp
@@ -1,5 +1,4 @@
 #include "Arduino.h"
-#include "SoftwareSerial.h"
 #include "BitsAndDroidsFlightConnector.h"
 
 
@@ -21,7 +20,7 @@ BitsAndDroidsFlightConnector::BitsAndDroidsFlightConnector(
   }
 }
 
-
+#ifndef ARDUINO_SAM_DUE
 BitsAndDroidsFlightConnector::BitsAndDroidsFlightConnector(
   bool isLeonardoMicro, SoftwareSerial* serial) {
   this->serial = serial;
@@ -30,6 +29,17 @@ BitsAndDroidsFlightConnector::BitsAndDroidsFlightConnector(
     serial->setTimeout(50);
   }
 }
+#else
+BitsAndDroidsFlightConnector::BitsAndDroidsFlightConnector(
+  bool isLeonardoMicro, Serial_* serial) {
+  this->serial = serial;
+  if (isLeonardoMicro) {
+    serial->begin(115200);
+    serial->setTimeout(50);
+  }
+}
+
+#endif
 
 void BitsAndDroidsFlightConnector::sendCombinedThrottleValues() {
   packagedData = sprintf(valuesBuffer, "%s %i %i %i %i", "199", engines[0],

--- a/BitsAndDroidsFlightConnector.cpp
+++ b/BitsAndDroidsFlightConnector.cpp
@@ -1,32 +1,51 @@
 #include "Arduino.h"
+#include "SoftwareSerial.h"
 #include "BitsAndDroidsFlightConnector.h"
-
 
 
 BitsAndDroidsFlightConnector::BitsAndDroidsFlightConnector(
   bool isLeonardoMicro) {
+  this->serial = &Serial;
   if (isLeonardoMicro) {
     Serial.begin(115200);
     Serial.setTimeout(50);
   }
 }
 
+BitsAndDroidsFlightConnector::BitsAndDroidsFlightConnector(
+  bool isLeonardoMicro, HardwareSerial* serial) {
+  this->serial = serial;
+  if (isLeonardoMicro) {
+    serial->begin(115200);
+    serial->setTimeout(50);
+  }
+}
+
+
+BitsAndDroidsFlightConnector::BitsAndDroidsFlightConnector(
+  bool isLeonardoMicro, SoftwareSerial* serial) {
+  this->serial = serial;
+  if (isLeonardoMicro) {
+    serial->begin(115200);
+    serial->setTimeout(50);
+  }
+}
 
 void BitsAndDroidsFlightConnector::sendCombinedThrottleValues() {
   packagedData = sprintf(valuesBuffer, "%s %i %i %i %i", "199", engines[0],
                          engines[1], engines[2], engines[3]);
-  Serial.println(valuesBuffer);
+  this->serial->println(valuesBuffer);
 }
 void BitsAndDroidsFlightConnector::sendCombinedPropValues() {
   packagedData = sprintf(valuesBuffer, "%s %i %i", "198", props[0], props[1]);
-  Serial.println(valuesBuffer);
+  this->serial->println(valuesBuffer);
 }
 void BitsAndDroidsFlightConnector::sendCombinedMixtureValues() {
 
          packagedData = sprintf(valuesBuffer, "%s %i %i", "115", mixturePercentage[0], mixturePercentage[1]);
 
 
-  Serial.println(valuesBuffer);
+  this->serial->println(valuesBuffer);
 }
 
 byte BitsAndDroidsFlightConnector::getPercentage(int value, int minVal, float maxVal) {
@@ -44,8 +63,8 @@ bool convBool(String input) {
 
 void BitsAndDroidsFlightConnector::dataHandling() {
 
-  if (Serial.available() > 0) {
-    receivedValue = Serial.readStringUntil('\n');
+  if (this->serial->available() > 0) {
+    receivedValue = this->serial->readStringUntil('\n');
     switchHandling();
   }
 

--- a/BitsAndDroidsFlightConnector.h
+++ b/BitsAndDroidsFlightConnector.h
@@ -1,7 +1,9 @@
 #ifndef BitsAndDroidsFlightConnector_h
 #define BitsAndDroidsFlightConnector_h
 
+#ifndef ARDUINO_SAM_DUE
 #include "SoftwareSerial.h"
+#endif
 
 // library interface description
 class BitsAndDroidsFlightConnector {
@@ -9,7 +11,11 @@ class BitsAndDroidsFlightConnector {
  public:
   BitsAndDroidsFlightConnector(bool isLeonardoMicro);
   BitsAndDroidsFlightConnector(bool isLeonardoMicro, HardwareSerial* serial);
+  #ifndef ARDUINO_SAM_DUE
   BitsAndDroidsFlightConnector(bool isLeonardoMicro, SoftwareSerial* serial);
+  #else
+  BitsAndDroidsFlightConnector(bool isLeonardoMicro, Serial_* serial);
+  #endif
   
   void switchHandling();
   void dataHandling();

--- a/BitsAndDroidsFlightConnector.h
+++ b/BitsAndDroidsFlightConnector.h
@@ -1,12 +1,16 @@
-
 #ifndef BitsAndDroidsFlightConnector_h
 #define BitsAndDroidsFlightConnector_h
+
+#include "SoftwareSerial.h"
 
 // library interface description
 class BitsAndDroidsFlightConnector {
   // user-accessible "public" interface
  public:
   BitsAndDroidsFlightConnector(bool isLeonardoMicro);
+  BitsAndDroidsFlightConnector(bool isLeonardoMicro, HardwareSerial* serial);
+  BitsAndDroidsFlightConnector(bool isLeonardoMicro, SoftwareSerial* serial);
+  
   void switchHandling();
   void dataHandling();
   void simpleInputHandling(int throttlePin,int minVal, float maxVal, bool reversed);
@@ -705,6 +709,7 @@ class BitsAndDroidsFlightConnector {
   // These values can be ommited and printed to serial directly
   // They are mainly implemented to improve readability of your code
 
+  Stream* serial;
 
   // Avionics
   int valSendAvionicsMaster1On = 401;


### PR DESCRIPTION
While trying out Bits and Droids (on a Arduino Due board), we stumbled over the issue, that the Serial port for communication cannot be specified.

To resolve this issue, I added 2 constructors, taking either a SoftwareSerial or a HardwareSerial as a second parameter.
The default behavior should not have changed, as the default constructor uses Serial and no existing code should break, because the one existing constructor still exists.

Looking forward to your feedback