### PR TITLE
Fix cutValue substring positon in switchHandling()

### DIFF
--- a/BitsAndDroidsFlightConnector.cpp
+++ b/BitsAndDroidsFlightConnector.cpp
@@ -160,7 +160,7 @@ void BitsAndDroidsFlightConnector::dataHandling() {
 void BitsAndDroidsFlightConnector::switchHandling() {
 
     prefix = receivedValue.substring(0, 3);
-    cutValue = receivedValue.substring(3);
+    cutValue = receivedValue.substring(4);
     int prefixVal = prefix.toInt();
     lastPrefix = prefixVal;
 


### PR DESCRIPTION
cutValue position was off by one, resulting in wrong or no value getting parsed (was 3, needs to be 4)